### PR TITLE
Ako/ use action commit hash

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Comment on pull request with App ID and URLs
         id: sticky_comment_on_pr
         if: steps.generate_app_id.outputs.should_post_comment
-        uses: marocchino/sticky-pull-request-comment@v1
+        uses: marocchino/sticky-pull-request-comment@6804b5ad49d19c10c9ae7cf5057352f7ff333f31
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           header: deriv-app-id-action


### PR DESCRIPTION
this is to use action commit hash instead of version to reduce the vulnerability.