### PR TITLE
[FEQ] Jim/FEQ-2059/update occurrences of binary-com to deriv-com

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
       - name: Capture Vercel preview URL
         id: vercel_preview_url
-        uses: binary-com/vercel-preview-url-action@master
+        uses: binary-com/vercel-preview-url-action@master # TODO: Update this to reference deriv-com/vercel-preview-url-action once it's migrated
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate Deriv App ID for deployment Preview URL
         id: generate_app_id
-        uses: binary-com/deriv-app-id-action@master
+        uses: deriv-com/deriv-app-id-action@master
         with:
           DERIV_API_TOKEN: ${{ secrets.DERIV_API_TOKEN }}
           DERIV_APP_ID: ${{ secrets.DERIV_APP_ID }},

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/binary-com/deriv-app-id-action.git"
+    "url": "git+https://github.com/deriv-com/deriv-app-id-action.git"
   },
   "keywords": [],
   "author": "Aaron Imming",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/binary-com/deriv-app-id-action/issues"
+    "url": "https://github.com/deriv-com/deriv-app-id-action/issues"
   },
-  "homepage": "https://github.com/binary-com/deriv-app-id-action#readme",
+  "homepage": "https://github.com/deriv-com/deriv-app-id-action#readme",
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",


### PR DESCRIPTION
## Changes
- Updated all references of `binary-com` with `deriv-com` except for the one whose repository hasn't been migrated (binary-com/vercel-preview-url-action@master)